### PR TITLE
Guards!

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ If applicable, add screenshots to help explain your problem.
 
 **please complete the following information:**
 
-- `rustc --version`: [e.g. 1.54.0]
+- `rustc --version`: [e.g. 1.55.0]
 - Crate version (if applicable): [e.g. 0.1.0]
 
 **Additional context**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [macos, ubuntu, windows]
-        rust: ['1.54', stable, beta, nightly]
+        rust: ['1.55', stable, beta, nightly]
     env:
       target: ${{matrix.target && format('--target={0}', matrix.target)}}
       workspace: ${{matrix.no-workspace || '--workspace'}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ TODO: Date
   - Increased minimum Rust version to 1.54,
     > which comes with the project template update.
 
+- Features:
+  - Added `Guard` struct that acts as type-erased drop guard for shared `Node`s.
+
 - Revisions:
   - Adjusted CHANGELOG formatting.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 <!-- markdownlint-disable no-trailing-punctuation -->
 
+TODO: Backport feature level 1 to the 0.1 branch.
+
 ## next
 
 TODO: Date
 
 - **Breaking changes:**
-  - Increased minimum Rust version to 1.54,
-    > which comes with the project template update.
+  - Increased minimum Rust version to 1.55,
+    > in order to use `MaybeUninit::write`.
+    >
+    > A Rust version upgrade had also been incurred by the updated Rust-template.
 
 - Features:
   - Added `Guard` struct that acts as type-erased drop guard for shared `Node`s.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/lignin)](https://crates.io/crates/lignin)
 [![Docs.rs](https://docs.rs/lignin/badge.svg)](https://docs.rs/lignin)
 
-![Rust 1.54](https://img.shields.io/static/v1?logo=Rust&label=&message=1.54&color=grey)
+![Rust 1.55](https://img.shields.io/static/v1?logo=Rust&label=&message=1.55&color=grey)
 [![CI](https://github.com/Tamschi/lignin/workflows/CI/badge.svg?branch=develop)](https://github.com/Tamschi/lignin/actions?query=workflow%3ACI+branch%3Adevelop)
 ![Crates.io - License](https://img.shields.io/crates/l/lignin/0.1.0)
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -2,12 +2,16 @@
 //!
 //! If a [`Node`] producer neither caches nor can act as container for other components which may, then it's fine to return a plain [`Node`] or [`&Node`](https://doc.rust-lang.org/stable/std/primitive.reference.html).
 
-use crate::{Node, ThreadSafety};
+use crate::{Node, ThreadBound, ThreadSafety};
 use core::{
 	marker::PhantomData,
 	mem::MaybeUninit,
 	ops::{Deref, DerefMut},
 };
+
+use self::auto_safety::{AutoSafe, Wrapper};
+
+pub mod auto_safety;
 
 /// A type-erased callback that's consumed upon calling and doesn't need to be allocated inside a `Box<_>`.
 ///
@@ -198,6 +202,12 @@ impl<'a, S: ThreadSafety> Guard<'a, S> {
 				guarded: self.guarded.take(),
 			}
 		}
+	}
+
+	/// Anonymises this instance for thread safety smuggling.
+	#[must_use]
+	pub fn into_auto_safe(self) -> impl AutoSafe<'a, BoundOrActual = Guard<'a, ThreadBound>> {
+		Wrapper::new(self)
 	}
 }
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -82,9 +82,6 @@ impl<'a> ConsumedCallback<'a> {
 /// ```
 ///
 /// ```rust
-/// extern crate alloc;
-///
-/// use alloc::boxed::Box;
 /// use lignin::{guard::ConsumedCallback, Guard, Node, ThreadSafety};
 ///
 /// /// An efficient allocator that can reclaim instances leaked into it.

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -2,14 +2,12 @@
 //!
 //! If a [`Node`] producer neither caches nor can act as container for other components which may, then it's fine to return a plain [`Node`] or [`&Node`](https://doc.rust-lang.org/stable/std/primitive.reference.html).
 
-use crate::{Node, ThreadBound, ThreadSafe, ThreadSafety};
+use crate::{Node, ThreadSafe, ThreadSafety};
 use core::{
 	marker::PhantomData,
 	mem::MaybeUninit,
 	ops::{Deref, DerefMut},
 };
-
-use self::auto_safety::{AutoSafe, Wrapper};
 
 pub mod auto_safety;
 
@@ -213,12 +211,6 @@ impl<'a, S: ThreadSafety> Guard<'a, S> {
 				guarded: self.guarded.take(),
 			}
 		}
-	}
-
-	/// Anonymises this instance for thread safety smuggling.
-	#[must_use]
-	pub fn into_auto_safe(self) -> impl AutoSafe<BoundOrActual = Guard<'a, ThreadBound>> {
-		Wrapper::new(self)
 	}
 }
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -1,0 +1,141 @@
+//! A VDOM [`Drop`] guard for compatibility between caching components and containers in general.
+//!
+//! If a [`Node`] producer neither caches nor can act as container for other components which may, then it's fine to return a plain [`Node`] or [`&Node`](https://doc.rust-lang.org/stable/std/primitive.reference.html).
+
+use crate::{Node, ThreadSafety};
+use core::{marker::PhantomData, mem::MaybeUninit};
+
+/// A type-erased callback that's consumed upon calling and doesn't need to be allocated inside a `Box<_>`.
+///
+/// > This should really be either a trait callable with `self: *const Self` or better yet
+/// > a `Pin<Box<dyn Send + Sync + Guarded>, Pointing>` where [`Pointing: Allocator`](https://doc.rust-lang.org/stable/core/alloc/trait.Allocator.html)
+/// > does absolution nothing. Both is unstable, though.
+#[must_use = "Dropping a `ConsumeCallback` does not call it, potentially leaking memory."]
+pub struct ConsumedCallback<'a> {
+	call: fn(*const ()),
+	with: *const (),
+	_phantom: PhantomData<&'a ()>,
+}
+impl<'a> ConsumedCallback<'a> {
+	/// Creates a new instance of [`ConsumedCallback`].
+	///
+	/// # Safety
+	///
+	/// `call` may be called up to once, with `with`, but only within `'a`.
+	pub unsafe fn new(call: fn(*const ()), with: *const ()) -> Self {
+		Self {
+			call,
+			with,
+			_phantom: PhantomData,
+		}
+	}
+
+	/// Invokes the callback.
+	pub fn call(self) {
+		(self.call)(self.with)
+	}
+}
+
+/// A drop guard for a shared [`Node`].
+///
+/// # Implementation Contract
+///
+/// [`Guard`] consumers **may** delay dropping them arbitrarily, so [`Guard`] producers **should not** rely on that for correctness.
+///
+/// [`Guard`] consumers **should not** leak them, as [`Guard`] producers **may** leak memory in such a case.
+///
+/// > These are strong suggestions, since those "**may**"s are likely to be quite common.
+/// >
+/// > For example, a double-buffering differ running in a browser, as of writing e.g. [lignin-dom](https://docs.rs/lignin-dom/latest/lignin_dom/),
+/// > will always delay dropping past the rendering of the updated VDOM.
+/// >
+/// > On a server, it may make sense to create an atomically- and periodically updated cache for part of the page,
+/// > if it renders very slowly for some reason. (I.e. an app could render out a VDOM while calculating or retrieving data synchronously, even if it *probably shouldn't*.)
+/// >
+/// > In terms of leaks, a good example is subtree caching, which due to delayed [`Guard`] drops **must** store any number of states as necessary or panic if it won't/can't at some point.
+pub struct Guard<'a, S: ThreadSafety> {
+	vdom: &'a Node<'a, S>,
+	guarded: Option<ConsumedCallback<'a>>,
+}
+impl<'a, S: ThreadSafety> Guard<'a, S> {
+	/// Creates a new instance of [`Guard`] which calls `guarded` once only when dropped.
+	#[must_use]
+	pub fn new_with_callback(vdom: &'a Node<'a, S>, guarded: Option<ConsumedCallback<'a>>) -> Self {
+		Self { vdom, guarded }
+	}
+
+	///
+	/// # Safety
+	///
+	/// The returned [`Node`] reference becomes invalid once the returned [`ConsumedCallback`] is called.
+	#[must_use = "Calling this method may leak memory unless any returned `ConsumedCallback` is called later on."]
+	pub unsafe fn leak(mut self) -> (&'a Node<'a, S>, Option<ConsumedCallback<'a>>) {
+		(self.vdom, self.guarded.take())
+	}
+
+	/// Splits off and stores this [`Guard`]'s drop-[`ConsumedCallback`], leaving an [`&Node<'a, S>`](`Node`).
+	///
+	/// # Safety
+	///
+	/// The returned [`Node`] reference becomes invalid once `add_to`'s value is called, if [`Some`] after this call.
+	pub unsafe fn peel(
+		mut self,
+		add_to: &mut Option<ConsumedCallback<'a>>,
+		allocate: impl FnOnce() -> &'a mut MaybeUninit<[ConsumedCallback<'a>; 2]>,
+	) -> &'a Node<'a, S> {
+		if let Some(peel) = self.guarded.take() {
+			*add_to = Some(match add_to.take() {
+				Some(previous) => {
+					fn call_both(both: *const ()) {
+						let [first, second] =
+							unsafe { both.cast::<[ConsumedCallback<'static>; 2]>().read() };
+						first.call();
+						second.call();
+					}
+					let both = (allocate().write([previous, peel])
+						as *const [ConsumedCallback<'a>; 2])
+						.cast();
+					ConsumedCallback::new(call_both, both)
+				}
+				None => peel,
+			});
+		}
+		self.vdom
+	}
+
+	/// Transforms the VDOM without manipulating the callback.
+	pub fn map<S2: ThreadSafety>(
+		mut self,
+		f: impl for<'any> FnOnce(&'any Node<'any, S>) -> &'any Node<'any, S2>,
+	) -> Guard<'a, S2> {
+		Guard {
+			vdom: f(self.vdom),
+			guarded: self.guarded.take(),
+		}
+	}
+
+	/// Transforms the VDOM, optionally adding on another callback.
+	pub fn flat_map<S2: ThreadSafety>(
+		mut self,
+		allocate: impl FnOnce() -> &'a mut MaybeUninit<[ConsumedCallback<'a>; 2]>,
+		f: impl for<'any> FnOnce(&'any Node<'any, S>) -> Guard<'any, S2>,
+	) -> Guard<'a, S2> {
+		unsafe {
+			//SAFETY:
+			// `self.vdom` can't escape from `f` due to its `'any` lifetime there.
+			// The peeled callback is immediately recombined.
+			Guard {
+				vdom: f(self.vdom).peel(&mut self.guarded, allocate),
+				guarded: self.guarded.take(),
+			}
+		}
+	}
+}
+
+impl<S: ThreadSafety> Drop for Guard<'_, S> {
+	fn drop(&mut self) {
+		if let Some(guarded) = self.guarded.take() {
+			guarded.call()
+		}
+	}
+}

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -100,7 +100,8 @@ impl<'a> ConsumedCallback<'a> {
 ///     let raw = allocate().write(unsafe {
 ///         //SAFETY:
 ///         // `callback` is rejoined with the peeled `Node`s below,
-///         // as `Guard::new` satisfies `ConsumedCallback::leak`'s and `ConsumedCallback::peel`'s safety contracts.
+///         // as `Guard::new` satisfies `ConsumedCallback::leak`'s and
+///         // `ConsumedCallback::peel`'s safety contracts.
 ///         [
 ///             {
 ///                 let (node, callback_) = c1().leak();

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -206,7 +206,7 @@ impl<'a, S: ThreadSafety> Guard<'a, S> {
 
 	/// Anonymises this instance for thread safety smuggling.
 	#[must_use]
-	pub fn into_auto_safe(self) -> impl AutoSafe<'a, BoundOrActual = Guard<'a, ThreadBound>> {
+	pub fn into_auto_safe(self) -> impl AutoSafe<BoundOrActual = Guard<'a, ThreadBound>> {
 		Wrapper::new(self)
 	}
 }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -3,7 +3,11 @@
 //! If a [`Node`] producer neither caches nor can act as container for other components which may, then it's fine to return a plain [`Node`] or [`&Node`](https://doc.rust-lang.org/stable/std/primitive.reference.html).
 
 use crate::{Node, ThreadSafety};
-use core::{marker::PhantomData, mem::MaybeUninit};
+use core::{
+	marker::PhantomData,
+	mem::MaybeUninit,
+	ops::{Deref, DerefMut},
+};
 
 /// A type-erased callback that's consumed upon calling and doesn't need to be allocated inside a `Box<_>`.
 ///
@@ -194,6 +198,20 @@ impl<'a, S: ThreadSafety> Guard<'a, S> {
 				guarded: self.guarded.take(),
 			}
 		}
+	}
+}
+
+impl<'a, S: ThreadSafety> Deref for Guard<'a, S> {
+	type Target = Node<'a, S>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.vdom
+	}
+}
+
+impl<S: ThreadSafety> DerefMut for Guard<'_, S> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.vdom
 	}
 }
 

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -41,7 +41,7 @@ impl<'a, S: ThreadSafety> __<'a, S> {
 /// Static thread safety smuggling through `impl AutoSafe` returns for [`Guard`] instances.
 pub trait AutoSafe<'a>: Sealed + Sized + IntoAutoSafe<'a, AutoSafe = Self> {
 	/// When specified in consumer code (in the `impl` return type), use the bound variant here.
-	type BoundOrActual;
+	type BoundOrActual: 'a;
 
 	/// Call this function as `AutoSafe::deanonymize(…)` on an `&mut &mut impl Autosafe<'a>` [yes, double-mut]
 	/// to statically retrieve an instance with the actual type.

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -99,13 +99,13 @@ macro_rules! guard_AutoSafe_alias {
 			///
 			/// Iff this function was called on this instance before.
 			#[track_caller]
-			fn deanonymize(this: &mut Self) -> Self::BoundOrActual;
+			fn deanonymize(this: &mut Self) -> <Self as $Name>::BoundOrActual;
 		}
 		impl<T> $Name for T
 		where
 			T: $crate::guard::auto_safety::AutoSafe
 		{
-			type BoundOrActual = <T as $crate::guard::auto_safety::AutoSafe>>::BoundOrActual;
+			type BoundOrActual = <T as $crate::guard::auto_safety::AutoSafe>::BoundOrActual;
 
 			#[track_caller]
 			fn deanonymize(this: &mut Self) -> <Self as $Name>::BoundOrActual {

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -103,7 +103,9 @@ where
 macro_rules! guard_AutoSafe_alias {
 	($vis:vis $Name:ident) => {
 		/// An alias for [`$crate::auto_safety::AutoSafe`] with custom visibility.
-		$vis trait $Name: $crate::guard::auto_safety::AutoSafe<Bound = <Self as $Name>::Bound> {}
+		$vis trait $Name: $crate::guard::auto_safety::AutoSafe<Bound = <Self as $Name>::Bound> {
+			type Bound: $crate::guard::auto_safety::Bound;
+		}
 		impl<T> $Name for T
 		where
 			T: $crate::guard::auto_safety::AutoSafe

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -65,7 +65,7 @@ impl<'a, S: ThreadSafety> AutoSafe<'a> for __<'a, S> {
 		}
 	}
 }
-impl<'a, T> AutoSafe<'a> for &'a mut T
+impl<'a, T: 'a> AutoSafe<'a> for &mut T
 where
 	T: Send + Sync + AutoSafe<'a, BoundOrActual = Guard<'a, ThreadBound>>,
 {
@@ -147,7 +147,7 @@ impl<'a, S: ThreadSafety> IntoAutoSafe<'a> for Guard<'a, S> {
 }
 
 /// Panics unconditionally. (Just here to satisfy constraints.)
-impl<'a, T> IntoAutoSafe<'a> for &'a mut T
+impl<'a, T: 'a> IntoAutoSafe<'a> for &mut T
 where
 	T: Send + Sync + AutoSafe<'a, BoundOrActual = Guard<'a, ThreadBound>>,
 {

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -1,0 +1,111 @@
+//! Analogous to [`crate::auto_safety`], but for [`Guard`]s.
+//!
+//! > This is likely a better API in general and may replace the one in [`crate::auto_safety`] in future versions.
+
+use crate::{auto_safety::Align, Guard, ThreadBound, ThreadSafe, ThreadSafety};
+use core::mem;
+use sealed::Sealed;
+
+mod sealed {
+	use super::{AutoSafe, Wrapper};
+	use crate::ThreadSafety;
+
+	pub trait Sealed {}
+	impl<S: ThreadSafety> Sealed for Wrapper<'_, S> {}
+	impl<'a, T> Sealed for &mut T where T: AutoSafe<'a> {}
+}
+
+pub(super) enum Wrapper<'a, S: ThreadSafety> {
+	Present(Guard<'a, S>),
+	Taken,
+}
+impl<'a, S: ThreadSafety> Wrapper<'a, S> {
+	pub(super) fn new(guard: Guard<'a, S>) -> Self {
+		Self::Present(guard)
+	}
+
+	#[track_caller]
+	fn take(&mut self) -> Guard<'a, S> {
+		match mem::replace(self, Self::Taken) {
+			Wrapper::Present(guard) => guard,
+			Wrapper::Taken => panic!("Tried to deanonymize `impl AutoGuard` twice. See `lignin::guard::auto_safety` for more information."),
+		}
+	}
+}
+
+/// Static thread safety smuggling through `impl AutoSafe` returns for [`Guard`] instances.
+pub trait AutoSafe<'a>: Sealed {
+	/// When specified in consumer code (in the `impl` return type), use the bound variant here.
+	type BoundOrActual: 'a;
+
+	/// Call this function as `AutoSafe::deanonymize(…)` on an `&mut &mut impl Autosafe<'a>` [yes, double-mut]
+	/// to statically retrieve an instance with the actual type.
+	///
+	/// # Panics
+	///
+	/// Iff this function was called on this instance before.
+	#[track_caller]
+	fn deanonymize(this: &mut Self) -> Self::BoundOrActual;
+}
+impl<'a, S: ThreadSafety> AutoSafe<'a> for Wrapper<'a, S> {
+	type BoundOrActual = Guard<'a, ThreadBound>;
+
+	#[track_caller]
+	fn deanonymize(this: &mut Self) -> Self::BoundOrActual {
+		let mut guard: Guard<'a, S> = this.take();
+		Guard {
+			vdom: guard.vdom.align(),
+			guarded: guard.guarded.take(),
+		}
+	}
+}
+impl<'a, T> AutoSafe<'a> for &mut T
+where
+	T: Send + Sync + AutoSafe<'a, BoundOrActual = Guard<'a, ThreadBound>>,
+{
+	type BoundOrActual = Guard<'a, ThreadSafe>;
+
+	#[track_caller]
+	fn deanonymize(this: &mut Self) -> Self::BoundOrActual {
+		// A `TypeId` check would be better, but isn't possible here because `T` isn't `'static`.
+		assert!(mem::size_of::<T>() == mem::size_of::<Wrapper<'a, ThreadSafe>>());
+		unsafe { &mut *(*this as *mut T).cast::<Wrapper<'a, ThreadSafe>>() }.take()
+	}
+}
+
+/// Mainly for use by frameworks. Canonically located at `guard::auto_safe::AutoSafe_alias`.  
+/// Creates a custom-visibility alias for [`guard::auto_safety::AutoSafe`](`AutoSafe`).
+///
+/// See [`auto_safety`#limiting-autosafe-exposure](`crate::auto_safety`#limiting-autosafe-exposure) for more information.
+#[macro_export]
+macro_rules! guard_AutoSafe_alias {
+	($vis:vis $Name:ident) => {
+		/// An alias for [`$crate::auto_safety::AutoSafe`] with custom visibility.
+		$vis trait $Name<'a>: $crate::guard::auto_safety::AutoSafe<'a> {
+			/// When specified in consumer code (in the `impl` return type), use the bound variant here.
+			type BoundOrActual: 'a;
+
+			/// Call this function as `AutoSafe::deanonymize(…)` on an `&mut &mut impl Autosafe<'a>` [yes, double-mut]
+			/// to statically retrieve an instance with the actual type.
+			///
+			/// # Panics
+			///
+			/// Iff this function was called on this instance before.
+			#[track_caller]
+			fn deanonymize(this: &mut Self) -> Self::BoundOrActual;
+		}
+		impl<'a, T $Name<'a> for T
+		where
+			T: $crate::guard::auto_safety::AutoSafe<'a>
+		{
+			type BoundOrActual = <T as $crate::guard::auto_safety::AutoSafe>>::BoundOrActual;
+
+			#[track_caller]
+			fn deanonymize(this: &mut Self) -> Self::BoundOrActual {
+				<T as $crate::guard::auto_safety::AutoSafe>::deanonymize(this)
+			}
+		}
+	};
+}
+
+pub use crate::guard_AutoSafe_alias as AutoSafe_alias;

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -108,7 +108,7 @@ macro_rules! guard_AutoSafe_alias {
 			type BoundOrActual = <T as $crate::guard::auto_safety::AutoSafe>>::BoundOrActual;
 
 			#[track_caller]
-			fn deanonymize(this: &mut Self) -> Self::BoundOrActual {
+			fn deanonymize(this: &mut Self) -> <Self as $Name>::BoundOrActual {
 				<T as $crate::guard::auto_safety::AutoSafe>::deanonymize(this)
 			}
 		}

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -14,7 +14,7 @@ mod sealed {
 	pub trait Sealed {}
 	#[allow(deprecated)]
 	impl<S: ThreadSafety> Sealed for __<'_, S> {}
-	impl<'a, T> Sealed for &mut T where T: AutoSafe {}
+	impl<'a, T> Sealed for &mut T where T: AutoSafe<'a> {}
 }
 
 #[doc(hidden)]
@@ -39,7 +39,7 @@ impl<'a, S: ThreadSafety> __<'a, S> {
 }
 
 /// Static thread safety smuggling through `impl AutoSafe` returns for [`Guard`] instances.
-pub trait AutoSafe: Sealed + Sized + IntoAutoSafe<AutoSafe = Self> {
+pub trait AutoSafe<'a>: Sealed + Sized + IntoAutoSafe<'a, AutoSafe = Self> {
 	/// When specified in consumer code (in the `impl` return type), use the bound variant here.
 	type BoundOrActual;
 
@@ -53,7 +53,7 @@ pub trait AutoSafe: Sealed + Sized + IntoAutoSafe<AutoSafe = Self> {
 	fn deanonymize(this: &mut Self) -> Self::BoundOrActual;
 }
 #[allow(deprecated)]
-impl<'a, S: ThreadSafety> AutoSafe for __<'a, S> {
+impl<'a, S: ThreadSafety> AutoSafe<'a> for __<'a, S> {
 	type BoundOrActual = Guard<'a, ThreadBound>;
 
 	#[track_caller]
@@ -65,9 +65,9 @@ impl<'a, S: ThreadSafety> AutoSafe for __<'a, S> {
 		}
 	}
 }
-impl<'a, T> AutoSafe for &'a mut T
+impl<'a, T> AutoSafe<'a> for &'a mut T
 where
-	T: Send + Sync + AutoSafe<BoundOrActual = Guard<'a, ThreadBound>>,
+	T: Send + Sync + AutoSafe<'a, BoundOrActual = Guard<'a, ThreadBound>>,
 {
 	type BoundOrActual = Guard<'a, ThreadSafe>;
 
@@ -88,9 +88,9 @@ where
 macro_rules! guard_AutoSafe_alias {
 	($vis:vis $Name:ident) => {
 		/// An alias for [`$crate::auto_safety::AutoSafe`] with custom visibility.
-		$vis trait $Name: $crate::guard::auto_safety::AutoSafe {
+		$vis trait $Name<'a>: $crate::guard::auto_safety::AutoSafe<'a> {
 			/// When specified in consumer code (in the `impl` return type), use the bound variant here.
-			type BoundOrActual;
+			type BoundOrActual: 'a;
 
 			/// Call this function as `AutoSafe::deanonymize(…)` on an `&mut &mut impl Autosafe<'a>` [yes, double-mut]
 			/// to statically retrieve an instance with the actual type.
@@ -101,9 +101,9 @@ macro_rules! guard_AutoSafe_alias {
 			#[track_caller]
 			fn deanonymize(this: &mut Self) -> <Self as $Name>::BoundOrActual;
 		}
-		impl<T> $Name for T
+		impl<'a, T> $Name<'a> for T
 		where
-			T: $crate::guard::auto_safety::AutoSafe
+			T: $crate::guard::auto_safety::AutoSafe<'a>
 		{
 			type BoundOrActual = <T as $crate::guard::auto_safety::AutoSafe>::BoundOrActual;
 
@@ -118,9 +118,9 @@ macro_rules! guard_AutoSafe_alias {
 pub use crate::guard_AutoSafe_alias as AutoSafe_alias;
 
 /// Provides idempotent (i.e. repeatable) [`AutoSafe`] conversion.
-pub trait IntoAutoSafe {
+pub trait IntoAutoSafe<'a> {
 	/// The resulting [`AutoSafe`].
-	type AutoSafe: AutoSafe;
+	type AutoSafe: AutoSafe<'a>;
 
 	/// Converts this instance into an [`AutoSafe`].
 	///
@@ -129,14 +129,14 @@ pub trait IntoAutoSafe {
 }
 
 #[allow(deprecated)]
-impl<S: ThreadSafety> IntoAutoSafe for __<'_, S> {
+impl<'a, S: ThreadSafety> IntoAutoSafe<'a> for __<'a, S> {
 	type AutoSafe = Self;
 
 	fn into_auto_safe(self) -> Self::AutoSafe {
 		self
 	}
 }
-impl<'a, S: ThreadSafety> IntoAutoSafe for Guard<'a, S> {
+impl<'a, S: ThreadSafety> IntoAutoSafe<'a> for Guard<'a, S> {
 	#[allow(deprecated)]
 	type AutoSafe = __<'a, S>;
 
@@ -147,9 +147,9 @@ impl<'a, S: ThreadSafety> IntoAutoSafe for Guard<'a, S> {
 }
 
 /// Panics unconditionally. (Just here to satisfy constraints.)
-impl<'a, T> IntoAutoSafe for &'a mut T
+impl<'a, T> IntoAutoSafe<'a> for &'a mut T
 where
-	T: Send + Sync + AutoSafe<BoundOrActual = Guard<'a, ThreadBound>>,
+	T: Send + Sync + AutoSafe<'a, BoundOrActual = Guard<'a, ThreadBound>>,
 {
 	#[allow(deprecated)]
 	type AutoSafe = Self;

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -99,17 +99,17 @@ macro_rules! guard_AutoSafe_alias {
 			///
 			/// Iff this function was called on this instance before.
 			#[track_caller]
-			fn deanonymize(this: &mut Self) -> <Self as $Name>::BoundOrActual;
+			fn deanonymize(this: &mut Self) -> <Self as $Name<'a>>::BoundOrActual;
 		}
 		impl<'a, T> $Name<'a> for T
 		where
 			T: $crate::guard::auto_safety::AutoSafe<'a>
 		{
-			type BoundOrActual = <T as $crate::guard::auto_safety::AutoSafe>::BoundOrActual;
+			type BoundOrActual = <T as $crate::guard::auto_safety::AutoSafe<'a>>::BoundOrActual;
 
 			#[track_caller]
-			fn deanonymize(this: &mut Self) -> <Self as $Name>::BoundOrActual {
-				<T as $crate::guard::auto_safety::AutoSafe>::deanonymize(this)
+			fn deanonymize(this: &mut Self) -> <Self as $Name<'a>>::BoundOrActual {
+				<T as $crate::guard::auto_safety::AutoSafe<'a>>::deanonymize(this)
 			}
 		}
 	};

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -39,7 +39,7 @@ impl<'a, S: ThreadSafety> __<'a, S> {
 }
 
 /// Static thread safety smuggling through `impl AutoSafe` returns for [`Guard`] instances.
-pub trait AutoSafe: Sealed + Sized + IntoAutoSafe {
+pub trait AutoSafe: Sealed + Sized {
 	/// When specified in consumer code (in the `impl` return type), use the bound variant here.
 	type BoundOrActual;
 
@@ -127,15 +127,17 @@ pub trait IntoAutoSafe {
 	/// Implemented as identity for types that are already [`AutoSafe`].
 	fn into_auto_safe(self) -> Self::AutoSafe;
 }
-
-#[allow(deprecated)]
-impl<S: ThreadSafety> IntoAutoSafe for __<'_, S> {
+impl<T> IntoAutoSafe for T
+where
+	T: AutoSafe,
+{
 	type AutoSafe = Self;
 
 	fn into_auto_safe(self) -> Self::AutoSafe {
 		self
 	}
 }
+
 impl<'a, S: ThreadSafety> IntoAutoSafe for Guard<'a, S> {
 	#[allow(deprecated)]
 	type AutoSafe = __<'a, S>;
@@ -143,18 +145,5 @@ impl<'a, S: ThreadSafety> IntoAutoSafe for Guard<'a, S> {
 	fn into_auto_safe(self) -> Self::AutoSafe {
 		#[allow(deprecated)]
 		__::new(self)
-	}
-}
-
-/// Panics unconditionally. (Just here to satisfy constraints.)
-impl<'a, T> IntoAutoSafe for &'a mut T
-where
-	T: Send + Sync + AutoSafe,
-{
-	#[allow(deprecated)]
-	type AutoSafe = __<'a, ThreadBound>;
-
-	fn into_auto_safe(self) -> Self::AutoSafe {
-		panic!("Called `IntoAutoSafe::into_auto_safe` on a reference.")
 	}
 }

--- a/src/guard/auto_safety.rs
+++ b/src/guard/auto_safety.rs
@@ -58,7 +58,7 @@ pub trait Deanonymize: Sealed + Sized {
 	///
 	/// Iff this function was called on this instance before.
 	#[track_caller]
-	unsafe fn deanonymize(this: &Self) -> Self::Actual;
+	unsafe fn deanonymize(&self) -> Self::Actual;
 }
 
 impl<'a, B: Bound, T: 'a> Deanonymize for &ManuallyDrop<T>
@@ -69,10 +69,10 @@ where
 
 	#[track_caller]
 	#[allow(deprecated)]
-	unsafe fn deanonymize(this: &Self) -> Self::Actual {
+	unsafe fn deanonymize(&self) -> Self::Actual {
 		// A `TypeId` check would be better, but isn't possible here because `T` isn't `'static`.
 		assert!(mem::size_of::<T>() == mem::size_of::<B::Safe>());
-		(*this as *const ManuallyDrop<T>)
+		(*self as *const ManuallyDrop<T>)
 			.cast::<Self::Actual>()
 			.read()
 	}
@@ -86,10 +86,10 @@ where
 
 	#[track_caller]
 	#[allow(deprecated)]
-	unsafe fn deanonymize(this: &Self) -> Self::Actual {
+	unsafe fn deanonymize(&self) -> Self::Actual {
 		// A `TypeId` check would be better, but isn't possible here because `T` isn't `'static`.
 		assert!(mem::size_of::<T>() == mem::size_of::<B>());
-		(this as *const ManuallyDrop<T>)
+		(self as *const ManuallyDrop<T>)
 			.cast::<Self::Actual>()
 			.read()
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
 //!
 //! [![Zulip Chat](https://img.shields.io/endpoint?label=chat&url=https%3A%2F%2Fiteration-square-automation.schichler.dev%2F.netlify%2Ffunctions%2Fstream_subscribers_shield%3Fstream%3Dproject%252Flignin)](https://iteration-square.schichler.dev/#narrow/stream/project.2Flignin)
 //!
-//! The primary compatibility types of this crate or [`Node`] and [`Guard`].
+//! The primary interop types are [`Node`] and [`Guard`],
+//! meaning these are the ones most intended to appear in dependent crates' APIs.
 //!
 //! # About the Documentation
 //!
@@ -671,7 +672,7 @@ mod sealed {
 }
 
 /// Marker trait for thread-safety tokens.
-pub trait ThreadSafety: Sealed + Into<ThreadBound>
+pub trait ThreadSafety: 'static + Sealed + Into<ThreadBound>
 where
 	Self: Sized + Debug + Clone + Copy + PartialEq + Eq + PartialOrd + Ord + Hash,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //!
 //! [![Zulip Chat](https://img.shields.io/endpoint?label=chat&url=https%3A%2F%2Fiteration-square-automation.schichler.dev%2F.netlify%2Ffunctions%2Fstream_subscribers_shield%3Fstream%3Dproject%252Flignin)](https://iteration-square.schichler.dev/#narrow/stream/project.2Flignin)
 //!
+//! The primary compatibility types of this crate or [`Node`] and [`Guard`].
+//!
 //! # About the Documentation
 //!
 //! DOM API terms are ***bold italic*** and linked to the MDN Web Docs.
@@ -134,10 +136,12 @@ mod readme {}
 
 pub mod auto_safety;
 pub mod callback_registry;
+pub mod guard;
 mod remnants;
 pub mod web;
 
 pub use callback_registry::{CallbackRef, CallbackRegistration};
+pub use guard::Guard;
 pub use web::{DomRef, Materialize};
 
 mod ergonomics;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,12 +137,12 @@ pub mod callback_registry;
 mod remnants;
 pub mod web;
 
-use callback_registry::CallbackSignature;
 pub use callback_registry::{CallbackRef, CallbackRegistration};
 pub use web::{DomRef, Materialize};
 
 mod ergonomics;
 
+use callback_registry::CallbackSignature;
 use core::{convert::Infallible, fmt::Debug, hash::Hash, marker::PhantomData};
 use remnants::RemnantSite;
 use sealed::Sealed;

--- a/tests/auto_traits.rs
+++ b/tests/auto_traits.rs
@@ -1,4 +1,4 @@
-use lignin::{web::Event, CallbackRegistration, Node, ThreadBound, ThreadSafe};
+use lignin::{web::Event, CallbackRegistration, Guard, Node, ThreadBound, ThreadSafe};
 use static_assertions::{assert_impl_all, assert_not_impl_any};
 
 assert_not_impl_any!(Node<ThreadBound>: Send, Sync);
@@ -6,3 +6,6 @@ assert_impl_all!(Node<ThreadSafe>: Send, Sync);
 
 assert_not_impl_any!(CallbackRegistration<*const (), fn(Event)>: Send, Sync);
 assert_impl_all!(CallbackRegistration<(), fn(Event)>: Send, Sync);
+
+assert_not_impl_any!(Guard<ThreadBound>: Send, Sync);
+assert_impl_all!(Guard<ThreadSafe>: Send, Sync);

--- a/tests/meta_constants_.rs
+++ b/tests/meta_constants_.rs
@@ -2,4 +2,4 @@
 
 pub const BRANCH: &str = "develop";
 pub const USER: &str = "Tamschi";
-pub const RUST_VERSION: &str = "1.54";
+pub const RUST_VERSION: &str = "1.55";


### PR DESCRIPTION
This adds `Node`-wrapping but otherwise type-erased drop guards, which can be used to reference-counter lasting shared `Node`s.